### PR TITLE
Simple fix for using scss file in a code-module component

### DIFF
--- a/apps/mobile/src/pages/home/home.html
+++ b/apps/mobile/src/pages/home/home.html
@@ -10,6 +10,7 @@
     <h2 text-center>
         {{counter$ | async}}
     </h2>
+    <app-my-component></app-my-component>
     <p text-center>
         <button ion-button (click)="increment()"> +1</button>
         <button ion-button (click)="decrement()"> -1</button>

--- a/libs/core/src/demo-core.module.ts
+++ b/libs/core/src/demo-core.module.ts
@@ -15,7 +15,8 @@ import {MyComponentComponent} from './my-component/my-component.component';
         EffectsModule.forFeature([CounterEffects])
     ],
     providers: [CounterEffects],
-    declarations: [MyComponentComponent]
+    declarations: [MyComponentComponent],
+    exports: [MyComponentComponent]
 })
 export class DemoCoreModule {
 }

--- a/libs/core/src/my-component/my-component.component.scss
+++ b/libs/core/src/my-component/my-component.component.scss
@@ -1,0 +1,4 @@
+app-my-component {
+    background: red;
+    display: block;
+}

--- a/libs/core/src/my-component/my-component.component.ts
+++ b/libs/core/src/my-component/my-component.component.ts
@@ -2,7 +2,8 @@ import {Component, OnInit} from '@angular/core';
 
 @Component({
     selector: 'app-my-component',
-    templateUrl: './my-component.component.html'
+    templateUrl: './my-component.component.html',
+    styleUrls: ['/my-component.component.scss']
 })
 export class MyComponentComponent implements OnInit {
     constructor() {


### PR DESCRIPTION
After I have opened an [issue](https://github.com/benorama/ngrx-demo-workspace/issues/1) here, I figured out a fix.
Changes:
- exporting `my-component` in `demo-core.module.ts` `exports` array of components
- change the scss file path by ionic docs
- added usage in home.html to test the component style